### PR TITLE
fixed reverted PR

### DIFF
--- a/app/components/appcomponents/LocalQuickReview.js
+++ b/app/components/appcomponents/LocalQuickReview.js
@@ -203,14 +203,14 @@ const LocalQuickReviewModal = ({ setIsLocalQuickReviewModalVisible }) => {
 
           // Fetch obituaries from yesterday to today (2 days range)
           const obituaryParams = {
-            city: parsedUser.city,
+            city: currUser.city,
             startDate: formattedYesterday,
             endDate: formattedToday,
           };
 
           // Fetch funerals for today and tomorrow (2 days range)
           const funeralParams = {
-            city: parsedUser.city,
+            city: currUser.city,
             startDate: formattedToday,
             endDate: formattedTomorrow,
           };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Local Quick Review now correctly uses your current city when fetching nearby obituaries and funeral details, preventing mismatched or out-of-area results.
  - Resolves an issue where some users saw listings tied to an outdated or incorrectly parsed location.
  - Improves accuracy and consistency of local results across the modal, including date display and combined results, with existing error handling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->