### PR TITLE
Revert "icon fix"

### DIFF
--- a/app/c/[slugKey]/nase_osmrtnice/page.js
+++ b/app/c/[slugKey]/nase_osmrtnice/page.js
@@ -204,7 +204,7 @@ export default function Obituaries() {
 
                       <td className="text-center">
                         <div className="flex items-center justify-center gap-3">
-                          {obituary?.hasKeeper === true ? (
+                          {obituary?.hasKeeper  ? (
                             <img
                               src="/tick_green.png"
                               alt=""


### PR DESCRIPTION
Reverts mm2439/obituary-app-fe#160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the keeper status indicator on obituary pages: a green tick now shows whenever keeper information is present, and a grey tick appears when it isn’t. This resolves inconsistent icon displays seen with non-boolean data inputs and ensures the status reflects the actual data more reliably. No other page behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->