### PR TITLE
text changes and default city change

### DIFF
--- a/app/components/appcomponents/OfficialOpening.js
+++ b/app/components/appcomponents/OfficialOpening.js
@@ -30,7 +30,7 @@ const OfficialOpening = () => {
           <div className="h-full w-full  flex flex-col justify-center items-center">
             <div className=" h-[174px] flex flex-col items-center mobile:items-end">
               <h1 className="text-[32px] text-center leading-[48px] font-variation-customOpt40 font-normal text-[#3C3E41]">
-                Uradna otvoritev je 5. septembra
+                Uradna otvoritev je 15. septembra
               </h1>
 
               <p className="text-[18px] leading-[48px] font-variation-customOpt24 font-bold text-[#3C3E41]">

--- a/app/components/appcomponents/OpeningDate.js
+++ b/app/components/appcomponents/OpeningDate.js
@@ -33,7 +33,7 @@ const OpeningDate = () => {
               <div className="flex  h-[174px] flex-col justify-between">
                 <div className="flex flex-col w-full h-[102px]">
                   <div className="text-[32px] text-[#3C3E41] font-variation-customOpt40 text-center mt-[-5px]">
-                    Uradna otvoritev je 5. septembra
+                    Uradna otvoritev je 15. septembra
                   </div>
                   <div className="text-[18px] text-[#3C3E41] font-bold mt-[3px] font-variation-customOpt24 text-center">
                     Izdelajte svojo spletno stran še pravočasno
@@ -59,7 +59,7 @@ const OpeningDate = () => {
             <div className="flex w-[478px] h-[174px] flex-col justify-between">
               <div className="flex flex-col w-full h-[102px]">
                 <div className="text-[32px] text-[#3C3E41] font-variation-customOpt40 text-left mt-[-5px]">
-                  Uradna otvoritev je 5. septembra
+                  Uradna otvoritev je 15. septembra
                 </div>
                 <div className="text-[18px] text-[#3C3E41] font-bold mt-[5px] font-variation-customOpt24 text-left">
                   Izdelajte svojo spletno stran še pravočasno
@@ -80,7 +80,7 @@ const OpeningDate = () => {
             <div className="flex  h-[195px] flex-col justify-between">
               <div className="flex flex-col w-full h-[102px]">
                 <div className="text-[24px] text-[#3C3E41] font-variation-customOpt28 text-center mt-[-5px] leading-[48px]">
-                  Uradna otvoritev je 5. septembra
+                  Uradna otvoritev je 15. septembra
                 </div>
                 <div className="text-[16px] text-[#3C3E41] font-bold mt-[2px] font-variation-customOpt20wght400 text-center leading-[48px]">
                   Izdelajte svojo spletno stran še pravočasno

--- a/app/components/appcomponents/PogrebiListComponent.js
+++ b/app/components/appcomponents/PogrebiListComponent.js
@@ -17,7 +17,7 @@ const ObituaryListComponent = ({ city }) => {
   const searchParams = useSearchParams();
 
   // Initialize state from URL params
-  const [selectedCity, setSelectedCity] = useState(searchParams.get('city') || city || "Ljubljana");
+  const [selectedCity, setSelectedCity] = useState(searchParams.get('city') || city || "Celje");
   const [selectedRegion, setSelectedRegion] = useState(searchParams.get('region') || null);
   const [searchTerm, setSearchTerm] = useState('');
   const [obituaries, setObituaries] = useState([]);
@@ -118,7 +118,7 @@ const ObituaryListComponent = ({ city }) => {
   // Set default city in URL if none is specified
   useEffect(() => {
     if (!searchParams.get('city') && !city) {
-      updateURL("Ljubljana", selectedRegion, searchTerm);
+      updateURL("Celje", selectedRegion, searchTerm);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/app/resitve-za-cvetlicarne/page.js
+++ b/app/resitve-za-cvetlicarne/page.js
@@ -41,7 +41,7 @@ const Floristspromo = () => {
             <div className="flex flex-col w-full mt-[10px]">
               <div className="text-[32px] mobile:text-[24px] text-[#3C3E41] font-light text-center leading-[48px]">
                 Uradna otvoritev je
-                <br /> 5. septembra
+                <br /> 15. septembra
               </div>
               <div className="my-6 text-[18px] hidden mobile:block mobile:text-[18px] text-[#3C3E41] font-bold font-variation-customOpt24 text-center leading-[32px]">
                 Izdelajte svojo spletno stran še pravočasno


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Pogrebi list now defaults to Celje when no city is specified via URL or props.

- Chores
  - Updated displayed official opening date from 5 September to 15 September across relevant pages and components (desktop, tablet, and mobile views).
  - Adjusted related UI copy to reflect the new date consistently.

- Documentation
  - Public-facing text refreshed to align with the updated opening date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->