### PR TITLE
remove ham on 'pp'&'cv' + goBack implement

### DIFF
--- a/app/components/appcomponents/Header7.js
+++ b/app/components/appcomponents/Header7.js
@@ -4,8 +4,11 @@ import iconMenu from "@/public/icon_menu_black.png";
 import back_icon from "@/public/back_icon.png";
 import telephone_icon from "@/public/telephone_icon.png";
 import classNames from "classnames";
+import { useRouter } from "next/navigation";
 
-function ObituaryHeader({ from, data, handleCloseModal }) {
+function ObituaryHeader({ from, data, handleCloseModal, showHamburger= true }) {
+    const router = useRouter();
+
   return (
     <header
       key={data?.id}
@@ -26,7 +29,7 @@ function ObituaryHeader({ from, data, handleCloseModal }) {
                      "
           >
             <div className="flex items-center h-full">
-              <div className="flex flex-col">
+              <div className="flex flex-col" onClick={() => router.back()} >
                 <Image
                   src={back_icon}
                   className="
@@ -94,14 +97,14 @@ function ObituaryHeader({ from, data, handleCloseModal }) {
                     className="w-[40px] h-[40px] desktop:w-[50px] desktop:h-[50px]"
                   />
                 </button>
-              ) : (
+              ) : showHamburger ? (
                 <Image
                   src={iconMenu}
                   className="
                   h-5 w-6 tablet:h-[26.67px] tablet:w-[32px] desktop:h-[26.67px] desktop:w-[30.73px] 
                    "
                 />
-              )}
+              ): null}
             </div>
           </div>
         </div>

--- a/app/components/appcomponents/Layout.js
+++ b/app/components/appcomponents/Layout.js
@@ -25,7 +25,7 @@ const Layout = ({
   from,
   forFooter,
   isMegaMenuVisible,
-  megaMenu,
+  megaMenu,showHamburger=true,
   data = {},
   onChangeMemory = () => {},
   currentPage = "",
@@ -75,12 +75,14 @@ const Layout = ({
           handleCloseModal={isModalLayout ? handleCloseModal : undefined}
           data={data}
           from={5}
+          showHamburger={showHamburger}
         />
       ) : from == "7" ? (
         <Header7
           handleCloseModal={isModalLayout ? handleCloseModal : undefined}
           data={data}
           from={7}
+          showHamburger={showHamburger}
         />
       ) : from == "3" ? (
         <MemoryHeader onChange={onChangeMemory} />

--- a/app/cv/[slug]/page.js
+++ b/app/cv/[slug]/page.js
@@ -43,7 +43,7 @@ export default function FloristPage() {
                         {
                             company ?
 
-                                <Layout from={"7"} forFooter={"memorypage"} data={company}
+                                <Layout from={"7"} forFooter={"memorypage"} data={company} showHamburger={false}
                                     currentPage="">
                                     <div className="flex flex-1 flex-col bg-[#F5F7F9]">
                                         <div className="flex flex-col relative mx-auto overflow-auto w-full bg-[#F5F7F9]">

--- a/app/pp/[slug]/page.js
+++ b/app/pp/[slug]/page.js
@@ -49,6 +49,7 @@ export default function FuneralPage() {
                             forFooter={"company"}
                             isMegaMenuVisible={undefined}
                             megaMenu={undefined}
+                            showHamburger={false}
                         >
                             <div className="flex flex-col mx-auto w-full bg-[#F5F7F9]">
                                 <FuneralsCompanyBanner


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tap the header’s back area to return to the previous page.
  * Added a setting to show or hide the hamburger/menu icon in the header (shown by default).
  * Layout now passes the hamburger visibility setting to applicable header variants for consistency.
  * Company (cv) and Funeral (pp) pages now hide the hamburger menu for a cleaner, focused view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->